### PR TITLE
fix(safari): avoid card shrinking

### DIFF
--- a/src/components/Results/index.scss
+++ b/src/components/Results/index.scss
@@ -2,6 +2,8 @@
   width: 100%;
   max-width: 1024px;
   margin-bottom: 15px;
+  flex-shrink: 0;
+
   .card-body {
     padding-top: 1.5rem;
   }


### PR DESCRIPTION
## Before (Safari)

<img width="752" alt="Screen Shot 2019-10-28 at 1 10 55 PM" src="https://user-images.githubusercontent.com/1962469/67674189-868e9000-f984-11e9-8a8f-8db93726dc54.png">

## After (Safari)

<img width="752" alt="Screen Shot 2019-10-28 at 1 11 07 PM" src="https://user-images.githubusercontent.com/1962469/67674194-8a221700-f984-11e9-9f5c-2d5705547658.png">

## After (Chrome)

<img width="752" alt="Screen Shot 2019-10-28 at 1 11 23 PM" src="https://user-images.githubusercontent.com/1962469/67674201-8d1d0780-f984-11e9-9c2b-1685764afd69.png">
