### PR TITLE
Fix typo in Slovene translation

### DIFF
--- a/src/translations/data.json
+++ b/src/translations/data.json
@@ -333,7 +333,7 @@
     "mk": "Изработувач:",
     "sr": "Развио:",
     "hr": "Razvio:",
-    "sl": "Ravijalec:"
+    "sl": "Razvijalec:"
   },
   "aboutDeveloperName": {
     "en": "Sergey Cherebedov",


### PR DESCRIPTION
“Ravijalec” should be “Razvijalec”. Relevant SSKJ entry [here](https://fran.si/133/sskj2-slovar-slovenskega-knjiznega-jezika-2/3693599/razvijalec).