### PR TITLE
Tweak language order according to similarity

### DIFF
--- a/src/components/LangSelector/index.tsx
+++ b/src/components/LangSelector/index.tsx
@@ -28,12 +28,12 @@ const languageList = [
         value: 'be',
     },
     {
-        name: 'Česky',
-        value: 'cs',
-    },
-    {
         name: 'Polski',
         value: 'pl',
+    },
+    {
+        name: 'Česky',
+        value: 'cs',
     },
     {
         name: 'Slovenský',
@@ -52,12 +52,12 @@ const languageList = [
         value: 'sr',
     },
     {
-        name: 'Български',
-        value: 'bg',
-    },
-    {
         name: 'Македонски',
         value: 'mk',
+    },
+    {
+        name: 'Български',
+        value: 'bg',
     },
     {
         name: 'Deutsch',

--- a/src/components/Settings/index.tsx
+++ b/src/components/Settings/index.tsx
@@ -16,12 +16,12 @@ const interfaceLanguageList = [
         value: 'en',
     },
     {
-        name: 'Меджусловјанскы',
-        value: 'isv-Cyrl',
-    },
-    {
         name: 'Medžuslovjansky',
         value: 'isv-Latn',
+    },
+    {
+        name: 'Меджусловјанскы',
+        value: 'isv-Cyrl',
     },
     {
         name: 'Русский',
@@ -36,12 +36,12 @@ const interfaceLanguageList = [
         value: 'be',
     },
     {
-        name: 'Česky',
-        value: 'cs',
-    },
-    {
         name: 'Polski',
         value: 'pl',
+    },
+    {
+        name: 'Česky',
+        value: 'cs',
     },
     {
         name: 'Slovenský',
@@ -60,12 +60,12 @@ const interfaceLanguageList = [
         value: 'sr',
     },
     {
-        name: 'Български',
-        value: 'bg',
-    },
-    {
         name: 'Македонски',
         value: 'mk',
+    },
+    {
+        name: 'Български',
+        value: 'bg',
     },
 ];
 


### PR DESCRIPTION
Reorder language lists so that more closely related languages are closer together. For example, Polish is more similar to Belarusian than Czech is. This groups be→pl→cs and sr→mk→bg together, respectively.

I've also put isv-Latn ahead of isv-Cyrl in the list, since that's the order that's usually used on http://steen.free.fr/interslavic, but I can revert this change if needed.