### PR TITLE
fix/verb-conjugation

### DIFF
--- a/src/legacy/conjugationVerb.ts
+++ b/src/legacy/conjugationVerb.ts
@@ -712,9 +712,6 @@ function build_pfpp(pref, is, psi) {
         ppps = ppps.replace(/ziX/g, 'žX');
         ppps = ppps.replace(/tiX/g, 'ćX');
         ppps = ppps.replace(/diX/g, 'đX');
-        ppps = ppps.replace(/riX/g, 'řX');
-        ppps = ppps.replace(/liX/g, 'ľX');
-        ppps = ppps.replace(/niX/g, 'ňX');
         ppps = ppps.replace(/jiX/g, 'jX');
         ppps = ppps.replace(/šiX/g, 'šX');
         ppps = ppps.replace(/žiX/g, 'žX');


### PR DESCRIPTION
Fixes "lj, nj, rj" rules according to Jan van Steenbern's "Derivation of words":
http://steen.free.fr/interslavic/derivation.html

Proto-Slavic | OCS | Slavic | Interslavic (Etymological) | Interslavic (Standard) | Examples (Etymological) | Examples (Standard)
-- | -- | -- | -- | -- | -- | --
lь, lj, nь, nj | ль, нь | ESl./PL ľ/ń, otherwise ľ/l, ń/n | lj, nj | lj, nj | ljubiti, hvaljeńje <br> denj, hrånjeńje | ljubiti, hvaljenje <br> denj, hranjenje
rь, rj | рь | RU/PL/CZ/SL ŕ, otherwise r | ŕ, rj | r, rj | caŕ, tvorjeńje | car, tvorjenje
